### PR TITLE
Show error in screen when passwords don't match

### DIFF
--- a/src/pages/RegisterPage.js
+++ b/src/pages/RegisterPage.js
@@ -100,6 +100,11 @@ function RegisterPage() {
               *You must confirm the password
             </p>
           )}
+          {errors?.confirmPassword && (
+            <p className="register__container--form--errors">
+              {errors.confirmPassword.message}
+            </p>
+          )}
           <input
             type="password"
             placeholder="Confirm password"


### PR DESCRIPTION
# Add error message when user's passwords don't match

- Now if user's enter different passwords they will see a message, before this fix they didn't see an error and the form never submit.

Message : **The Passwords do not match**

![image](https://user-images.githubusercontent.com/82791480/134988912-f11f2fdc-6078-4a46-a6c7-0e60073638f7.png)
