### PR TITLE
Change max characters in name input register form

### DIFF
--- a/src/pages/RegisterPage.js
+++ b/src/pages/RegisterPage.js
@@ -40,7 +40,7 @@ function RegisterPage() {
           )}
           {errors?.name?.type === "maxLength" && (
             <p className="register__container--form--errors">
-              *A name cannot exceed 20 characters
+              *A name cannot exceed 40 characters
             </p>
           )}
           <input
@@ -50,7 +50,7 @@ function RegisterPage() {
             className="form__field"
             {...register("name", {
               required: true,
-              maxLength: 20,
+              maxLength: 40,
             })}
           />
           {errors?.email?.type === "required" && (


### PR DESCRIPTION
# Change characters name input limit

- Since we are going to have foundations as users, is very common to see long names from foundations.
- New limit **40 characters.**

![image](https://user-images.githubusercontent.com/82791480/134989223-c336d8ec-2da4-41b6-8fe7-f0a6b8550142.png)
