### PR TITLE
Fix minimum pet's age when creating one

### DIFF
--- a/src/pages/AddPet.js
+++ b/src/pages/AddPet.js
@@ -123,6 +123,7 @@ function AddPet() {
               type="number"
               name="petAge"
               id="age"
+              min="0"
               placeholder="Pet's age (Months)"
               onChange={InputChange}
               className="container__dropzone--input"


### PR DESCRIPTION
# Fix minimum pet's age when creating one

- There was an error that let foundations set the pet age as a negative number.
- Now it accepts positive values.

![image](https://user-images.githubusercontent.com/82791480/134989544-e0b0f576-1f4d-4fb0-933c-dda782bdd91a.png)
